### PR TITLE
Normalisation

### DIFF
--- a/src/ScattBO/utils/ScattBO.py
+++ b/src/ScattBO/utils/ScattBO.py
@@ -35,7 +35,6 @@ def calculate_scattering(
     rmin=0,
     rmax=30,
     rstep=0.1,
-    normalisation_mode='peak'
 ):
     """
     Calculate a Pair Distribution Function (PDF), Structure Factor (Sq), Form Factor (Fq), Intensity (Iq), or Small Angle X-ray Scattering (SAXS) from a given structure.
@@ -52,7 +51,6 @@ def calculate_scattering(
     rmin (float): The minimum r value for the Gr pattern calculations. Default is 0.
     rmax (float): The maximum r value for the Gr pattern calculations. Default is 30.
     rstep (float): The step size for r values in Gr. Default is 0.1.
-    normalisation_mode (str): The normalization mode. 'peak' for highest peak to 1, 'ML_standard' for -1 to 1, 'none' for no scaling. Default is 'peak'.
 
     Returns:
     r/q (numpy.ndarray): The r values (for PDF) or q values (for Sq, Fq, Iq, SAXS) from the calculated function.
@@ -86,23 +84,18 @@ def calculate_scattering(
 
     # Calculate scattering patterns
     if function == "Iq":
-        I = normalise_data(I, mode=normalisation_mode)
         return Q, I
     elif function == "Sq":
-        S = normalise_data(S, mode=normalisation_mode)
         return Q, S
     elif function == "Fq":
-        F = normalise_data(F, mode=normalisation_mode)
         return Q, F
     elif function == "Gr":
-        G = normalise_data(G, mode=normalisation_mode)
         return r, G
     elif function == "SAXS":
         calc.update_parameters(
             qmin_SAXS=qmin_SAXS, qmax_SAXS=qmax_SAXS, qstep_SAXS=qstep_SAXS
         )
         Q_sim, I_sim = calc.iq(structure_source=cluster)
-        I_sim = normalise_data(I_sim, mode=normalisation_mode)
         return Q_sim, I_sim
 
 def normalise_data(data, mode='peak'):
@@ -329,6 +322,7 @@ def ScatterBO_small_benchmark(
     qmin_SAXS=0.01,
     qmax_SAXS=3.0,
     qstep_SAXS=0.01,
+    normalisation_mode='peak',
 ):
     """
     Simulate a scattering pattern from synthesis parameters, load a target scattering pattern, and calculate the similarity between them.
@@ -354,6 +348,7 @@ def ScatterBO_small_benchmark(
     rmin (float): The minimum r value for the Gr pattern calculations. Default is 0.
     rmax (float): The maximum r value for the Gr pattern calculations. Default is 30.
     rstep (float): The step size for r values in Gr. Default is 0.1.
+    normalisation_mode (str): The normalization mode. 'peak' for highest peak to 1, 'ML_standard' for -1 to 1, 'none' for no scaling. Default is 'peak'.
 
     Returns:
     loss (float): The loss value is a measure of the difference between the simulated and target scattering patterns.
@@ -376,6 +371,10 @@ def ScatterBO_small_benchmark(
 
     # Load the target scattering data
     x_target, Int_target = LoadData(simulated_or_experimental, scatteringfunction)
+
+    # Normalise the target and simulated scattering patterns
+    Int_target = normalise_data(Int_target, mode=normalisation_mode)
+    Int_sim = normalise_data(Int_sim, mode=normalisation_mode)
 
     # Calculate the difference between the simulated and target scattering patterns
     loss, Int_sim_interp = calculate_loss(
@@ -418,6 +417,7 @@ def ScatterBO_large_benchmark(
     qmin_SAXS=0.01,
     qmax_SAXS=3.0,
     qstep_SAXS=0.01,
+    normalisation_mode='peak',
 ):
     """
     Simulate a scattering pattern from synthesis parameters, load a target scattering pattern, and calculate the similarity between them.
@@ -443,6 +443,7 @@ def ScatterBO_large_benchmark(
     rmin (float): The minimum r value for the Gr pattern calculations. Default is 0.
     rmax (float): The maximum r value for the Gr pattern calculations. Default is 30.
     rstep (float): The step size for r values in Gr. Default is 0.1.
+    normalisation_mode (str): The normalization mode. 'peak' for highest peak to 1, 'ML_standard' for -1 to 1, 'none' for no scaling. Default is 'peak'.
 
     Returns:
     loss (float): The loss value is a measure of the difference between the simulated and target scattering patterns.
@@ -465,6 +466,10 @@ def ScatterBO_large_benchmark(
 
     # Load the target scattering data
     x_target, Int_target = LoadData(simulated_or_experimental, scatteringfunction)
+
+    # Normalise the target and simulated scattering patterns
+    Int_target = normalise_data(Int_target, mode=normalisation_mode)
+    Int_sim = normalise_data(Int_sim, mode=normalisation_mode)
 
     # Calculate the difference between the simulated and target scattering patterns
     loss, Int_sim_interp = calculate_loss(
@@ -615,6 +620,7 @@ def ScatterBO_robotic_benchmark(
     qmin_SAXS=0.01,
     qmax_SAXS=3.0,
     qstep_SAXS=0.01,
+    normalisation_mode='peak',
 ):
     """
     Simulate a scattering pattern from synthesis parameters, load a target scattering pattern, and calculate the similarity between them.
@@ -644,6 +650,7 @@ def ScatterBO_robotic_benchmark(
     rmin (float): The minimum r value for the Gr pattern calculations. Default is 0.
     rmax (float): The maximum r value for the Gr pattern calculations. Default is 30.
     rstep (float): The step size for r values in Gr. Default is 0.1.
+    normalisation_mode (str): The normalization mode. 'peak' for highest peak to 1, 'ML_standard' for -1 to 1, 'none' for no scaling. Default is 'peak'.
 
     Returns:
     loss (float): The loss value is a measure of the difference between the simulated and target scattering patterns.
@@ -666,6 +673,10 @@ def ScatterBO_robotic_benchmark(
 
     # Load the target scattering data
     x_target, Int_target = LoadData(simulated_or_experimental, scatteringfunction)
+
+    # Normalise the target and simulated scattering patterns
+    Int_target = normalise_data(Int_target, mode=normalisation_mode)
+    Int_sim = normalise_data(Int_sim, mode=normalisation_mode)
 
     # Calculate the difference between the simulated and target scattering patterns
     loss, Int_sim_interp = calculate_loss(

--- a/tools/GenerateScatteringPatterns.py
+++ b/tools/GenerateScatteringPatterns.py
@@ -2,12 +2,16 @@ import numpy as np
 import plotly.graph_objects as go
 from plotly.subplots import make_subplots
 from ScattBO.utils import generate_structure, calculate_scattering
+from ScattBO.parameters.benchmark_parameters import BenchmarkParameters
 from pathlib import Path
 import os
 ROOT_DIR = Path(os.getcwd()).parent.resolve()
 
-# Generate the structure and calculate the scattering
-cluster = generate_structure(pH=10, pressure=75, solvent="Ethanol", atom="Au")
+# Create an instance of BenchmarkParameters
+params = BenchmarkParameters(pH=10, pressure=75, solvent="Ethanol", atom="Au")
+
+# Call the generate_structure function with the params instance
+cluster = generate_structure(params)
 q, I = calculate_scattering(cluster, function="Iq")
 q, S = calculate_scattering(cluster, function="Sq")
 q, F = calculate_scattering(cluster, function="Fq")


### PR DESCRIPTION
Before, we always normalised the data to the highest peak. I have now changed this so that the data loader and calculator no longer perform any normalisation.

I have added a function that offers various types of normalisations which can be applied to the data. These are then used in the benchmark functions after the data has been loaded and calculated.